### PR TITLE
Make entries configurable

### DIFF
--- a/types/standard/README.md
+++ b/types/standard/README.md
@@ -100,12 +100,11 @@ Example of mapstore configuration in package.json:
             "path/to/dir-themes", // scan directory for folder containing theme.less (name from folder)
             "path/to/dir-themes/default", // folder containing theme.less (name from folder)
             "path/to/dir-themes/default/theme.less" // theme.less file to use (name from folder)
-        ]
-    },
+        ],
         "templateParameters": {
             "favicon": "path/to/favicon"
         }
-    }
+    },
 }
 ```
 

--- a/types/standard/README.md
+++ b/types/standard/README.md
@@ -65,14 +65,20 @@ Folders and files description:
 
 The `mapstore` property inside the package.json allows to override and/or customize some configuration of the project. These are the available parameters:
 
-- `templateParameters` _{object}_ overrides parameters of default html templates (index.ejs, embedded.ejs, api.ejs and unsupportedBrowser.ejs)
-- templateParameters.`titleIndex` _{string}_
-- templateParameters.`titleEmbedded` _{string}_
-- templateParameters.`titleApi` _{string}_
-- templateParameters.`favicon` _{string}_
-- templateParameters.`loadingMessageIndex` _{string}_
-- templateParameters.`loadingMessageEmbedded` _{string}_
-- templateParameters.`titleUnsupported` _{string}_
+| property | type | description |
+| --- | --- | --- |
+| `apps` | _{array}_ | mapstore application location. List of .js or .jsx entries: directories or files |
+| `html` | _{array}_ | mapstore html templates location. List of .ejs or .html entries: directories or files |
+| `themes` | _{array}_ | mapstore .less themes location. List of .ejs or .html entries: directories or files |
+| `templateParameters` | _{object}_ | overrides parameters of default html templates (index.ejs, embedded.ejs, api.ejs and unsupportedBrowser.ejs) |
+| templateParameters.`titleIndex` | _{string}_ |  |
+| templateParameters.`titleEmbedded` | _{string}_ |  |
+| templateParameters.`titleApi` | _{string}_ |  |
+| templateParameters.`favicon` | _{string}_ |  |
+| templateParameters.`loadingMessageIndex` | _{string}_ |  |
+| templateParameters.`loadingMessageEmbedded` | _{string}_ |  |
+| templateParameters.`titleUnsupported` | _{string}_ |  |
+
 
 Example of mapstore configuration in package.json:
 
@@ -80,6 +86,22 @@ Example of mapstore configuration in package.json:
 {
     // ...others package.json properties,
     "mapstore": {
+        "apps": [
+            "path/to/dir-of-apps", // scan directory for js or jsx
+            "path/to/dir/index.js", // point to a single file
+            ["path/to/dir/fileName.js", "file-name"] // point to a single file and replace the bundle name 
+        ],
+        "html": [
+            "path/to/dir-of-ejs", // scan directory for ejs
+            "path/to/dir/index.ejs", // point to a single file
+            ["path/to/dir/pageName.ejs", "page-name.html"] // point to a single file and replace the html name
+        ],
+        "themes": [
+            "path/to/dir-themes", // scan directory for folder containing theme.less (name from folder)
+            "path/to/dir-themes/default", // folder containing theme.less (name from folder)
+            "path/to/dir-themes/default/theme.less" // theme.less file to use (name from folder)
+        ]
+    },
         "templateParameters": {
             "favicon": "path/to/favicon"
         }

--- a/types/standard/README.md
+++ b/types/standard/README.md
@@ -69,7 +69,7 @@ The `mapstore` property inside the package.json allows to override and/or custom
 | --- | --- | --- |
 | `apps` | _{array}_ | mapstore application location. List of .js or .jsx entries: directories or files |
 | `html` | _{array}_ | mapstore html templates location. List of .ejs or .html entries: directories or files |
-| `themes` | _{array}_ | mapstore .less themes location. List of .ejs or .html entries: directories or files |
+| `themes` | _{array}_ | mapstore .less themes location: directories or files |
 | `templateParameters` | _{object}_ | overrides parameters of default html templates (index.ejs, embedded.ejs, api.ejs and unsupportedBrowser.ejs) |
 | templateParameters.`titleIndex` | _{string}_ |  |
 | templateParameters.`titleEmbedded` | _{string}_ |  |

--- a/types/standard/config/index.js
+++ b/types/standard/config/index.js
@@ -95,7 +95,7 @@ const appsPaths = mapstoreConfig.apps || [
     [path.join(webClientProductPath, 'api'), 'ms2-api'],
     path.join(appDirectory, 'js')
 ];
-const ejsPaths = mapstoreConfig.ejs || [
+const htmlPaths = mapstoreConfig.html || [
     path.resolve(__dirname, '..'), appDirectory
 ];
 const themesPaths = mapstoreConfig.themes || [
@@ -106,8 +106,11 @@ const jsPath = "js/";
 const apps = readEntriesPaths(appsPaths, ({ dirName, baseName, entryName }) => ({
     [jsPath + (entryName || baseName).replace(/\.jsx|\.js/g, '')]: path.join(dirName, baseName)
 }));
-const htmlTemplates = readEntriesPaths(ejsPaths, ({ dirName, baseName, entryName }) => baseName.indexOf('.ejs') !== -1
+const htmlTemplates = readEntriesPaths(htmlPaths, ({ dirName, baseName, entryName }) => baseName.indexOf('.ejs') !== -1
     ? { [entryName || baseName.replace('.ejs', '.html')]: path.join(dirName, baseName)} : {}
+);
+const html = readEntriesPaths(htmlPaths, ({ dirName, baseName, entryName }) => baseName.indexOf('.html') !== -1
+    ? { [entryName || baseName]: path.join(dirName, baseName)} : {}
 );
 const themes = readEntriesPaths(themesPaths, ({ dirName, baseName }) => {
     if (baseName.indexOf('theme.less') !== -1) {
@@ -136,5 +139,6 @@ module.exports = {
     apps,
     devServer: devServer(devServerDefault),
     htmlTemplates,
+    html,
     templateParameters: mapstoreConfig.templateParameters || {}
 };

--- a/types/standard/config/index.js
+++ b/types/standard/config/index.js
@@ -9,21 +9,22 @@
 const path = require('path');
 const fs = require('fs-extra');
 const info = require('../../../scripts/utils/info');
+const castArray = require('lodash/castArray');
 
 const appDirectory = fs.realpathSync(process.cwd());
 
 const packageJSON = require(path.join(appDirectory, 'package.json'));
-
-const isProject = !fs.existsSync(path.join(appDirectory, 'web', 'client', 'product'));
+const mapstoreConfig = packageJSON.mapstore || {};
 
 const { commit } = info();
 const version = commit;
 
-const themesPath = path.join(appDirectory, 'themes');
-const appsPath = path.join(appDirectory, 'js', 'apps');
+const frameworkPath = fs.existsSync(path.resolve(appDirectory, './MapStore2'))
+    ? path.join(appDirectory, 'MapStore2', 'web', 'client')
+    : path.join(appDirectory, 'node_modules', 'mapstore', 'web', 'client');
+const webClientProductPath = path.resolve(frameworkPath, 'product');
 const devServerPath = path.join(appDirectory, 'devServer.js');
-const themes = isProject && fs.existsSync(themesPath) ? fs.readdirSync(themesPath) : [];
-const apps = isProject && fs.existsSync(appsPath) ? fs.readdirSync(appsPath) : [];
+
 const devServerDefault = {
     proxy: {
         '/rest': {
@@ -55,32 +56,85 @@ const devServerDefault = {
         }
     }
 };
-const devServer = isProject && fs.existsSync(devServerPath) ? require(devServerPath) : () => devServerDefault;
+const devServer = fs.existsSync(devServerPath) ? require(devServerPath) : () => devServerDefault;
 
-const defaultHtmlTemplates = {
-    'index.html': path.resolve(__dirname, '../index.ejs'),
-    'embedded.html': path.resolve(__dirname, '../embedded.ejs'),
-    'unsupportedBrowser.html': path.resolve(__dirname, '../unsupportedBrowser.ejs'),
-    'api.html': path.resolve(__dirname, '../api.ejs')
-};
+function readEntriesPaths(entriesPaths, parse) {
+    return entriesPaths.reduce((acc, entriesPath) => {
+        const [targetPath, entryName] = castArray(entriesPath);
+        const absolutePath = path.isAbsolute(targetPath)
+            ? targetPath
+            : path.resolve(appDirectory, targetPath);
+        const stats = fs.lstatSync(absolutePath);
+        if (stats.isDirectory()) {
+            const dirName = absolutePath;
+            return fs.readdirSync(dirName)
+                .reduce((parsed, baseName) => ({
+                    ...parsed,
+                    ...parse({ dirName, baseName })
+                }), {});
+        }
+        if (stats.isFile()) {
+            const dirName = path.dirname(absolutePath);
+            const baseName = path.basename(absolutePath);
+            return {
+                ...acc,
+                ...parse({
+                    dirName,
+                    baseName,
+                    entryName
+                })
+            };
+        }
+        return acc;
+    }, {});
+}
 
-const htmlTemplates = fs.readdirSync(appDirectory)
-    .filter((file) => file.indexOf('.ejs') !== -1)
-    .reduce((acc, file) => ({
-        ...acc,
-        [file.replace('.ejs', '.html') ]: path.join(appDirectory, file)
-    }), {});
+const appsPaths = mapstoreConfig.apps || [
+    [path.join(webClientProductPath, 'app'), 'mapstore'],
+    path.join(webClientProductPath, 'embedded'),
+    [path.join(webClientProductPath, 'api'), 'ms2-api'],
+    path.join(appDirectory, 'js')
+];
+const ejsPaths = mapstoreConfig.ejs || [
+    path.resolve(__dirname, '..'), appDirectory
+];
+const themesPaths = mapstoreConfig.themes || [
+    path.join(appDirectory, 'themes')
+];
+const jsPath = "js/";
+
+const apps = readEntriesPaths(appsPaths, ({ dirName, baseName, entryName }) => ({
+    [jsPath + (entryName || baseName).replace(/\.jsx|\.js/g, '')]: path.join(dirName, baseName)
+}));
+const htmlTemplates = readEntriesPaths(ejsPaths, ({ dirName, baseName, entryName }) => baseName.indexOf('.ejs') !== -1
+    ? { [entryName || baseName.replace('.ejs', '.html')]: path.join(dirName, baseName)} : {}
+);
+const themes = readEntriesPaths(themesPaths, ({ dirName, baseName }) => {
+    if (baseName.indexOf('theme.less') !== -1) {
+        return {
+            ['themes/' + path.basename(dirName)]: path.join(dirName, baseName)
+        };
+    }
+    const themesFolder = path.join(dirName, baseName);
+    const stats = fs.lstatSync(themesFolder);
+    if (stats.isDirectory() && fs.readdirSync(themesFolder).indexOf('theme.less') !== -1) {
+        return {
+            ['themes/' + path.basename(themesFolder)]: path.join(themesFolder, 'theme.less')
+        };
+    }
+    return {};
+});
 
 module.exports = {
+    jsPath,
+    frameworkPath,
+    webClientProductPath,
     name: packageJSON.name,
     version,
     // translations,
     themes,
     apps,
     devServer: devServer(devServerDefault),
-    htmlTemplates: {
-        ...defaultHtmlTemplates,
-        ...htmlTemplates
-    },
-    templateParameters: packageJSON.mapstore && packageJSON.mapstore.templateParameters || {}
+    htmlTemplates,
+    templateParameters: mapstoreConfig.templateParameters || {}
 };

--- a/types/standard/config/prod-webpack.config.js
+++ b/types/standard/config/prod-webpack.config.js
@@ -19,24 +19,15 @@ const output = 'dist/';
 const projectConfig = require('./index.js');
 const templateParameters = require('./templateParameters');
 
-const isProject = !fs.existsSync(path.join(appDirectory, 'web', 'client', 'product'));
-
-const frameworkPath = !isProject
-    ? path.join(appDirectory, 'web', 'client')
-    : fs.existsSync(path.resolve(appDirectory, './MapStore2'))
-        ? path.join(appDirectory, 'MapStore2', 'web', 'client')
-        : path.join(appDirectory, 'node_modules', 'mapstore', 'web', 'client');
+const frameworkPath = projectConfig.frameworkPath;
 
 const buildConfig = require(path.resolve(frameworkPath, '../../build/buildConfig'));
 const extractThemesPlugin = require(path.resolve(frameworkPath, '../../build/themes.js')).extractThemesPlugin;
 
-const webClientProductPath = path.resolve(frameworkPath, 'product');
-const jsPath = "js";
+const jsPath = projectConfig.jsPath;
 const paths = {
     base: path.resolve(appDirectory),
-    dist: isProject
-        ? path.resolve(appDirectory, output)
-        : path.resolve(frameworkPath, output),
+    dist: path.resolve(appDirectory, output),
     framework: frameworkPath,
     chunks: jsPath + "/",
     code: [
@@ -48,22 +39,8 @@ const paths = {
 const themePrefix = projectConfig.name;
 
 module.exports = buildConfig({
-    bundles: {
-        [jsPath + '/mapstore']: path.join(webClientProductPath, 'app'),
-        [jsPath + '/embedded']: path.join(webClientProductPath, 'embedded'),
-        [jsPath + '/ms2-api']: path.join(webClientProductPath, 'api'),
-        ...(projectConfig.apps || []).reduce((acc, name) => ({
-            ...acc,
-            [jsPath + '/' + name.replace(/\.jsx|\.js/g, '')]: path.join(appDirectory, jsPath, 'apps', name)
-        }), {})
-    },
-    themeEntries: {
-        'themes/default': path.join(paths.framework, 'themes', 'default', 'theme.less'),
-        ...(projectConfig.themes || []).reduce((acc, name) => ({
-            ...acc,
-            ['themes/' + name]: path.join(appDirectory, 'themes', name, 'theme.less')
-        }), {})
-    },
+    bundles: projectConfig.apps,
+    themeEntries: projectConfig.themes,
     paths,
     plugins: [
         extractThemesPlugin,

--- a/types/standard/config/prod-webpack.config.js
+++ b/types/standard/config/prod-webpack.config.js
@@ -55,7 +55,11 @@ module.exports = buildConfig({
                 : [],
             ...fs.existsSync(path.join(paths.base, 'static'))
                 ? [{ from: path.join(paths.base, 'static'), to: path.join(paths.dist, 'static') }]
-                : []
+                : [],
+            ...Object.keys(projectConfig.html).map((name) => ({
+                from: projectConfig.html[name],
+                to: path.join(paths.dist, name)
+            }))
         ]),
         ...Object.keys(projectConfig.htmlTemplates).map((key) =>
             new HtmlWebpackPlugin({

--- a/types/standard/config/webpack.config.js
+++ b/types/standard/config/webpack.config.js
@@ -18,20 +18,12 @@ const output = '';
 const projectConfig = require('./index.js');
 const templateParameters = require('./templateParameters');
 
-const isProject = !fs.existsSync(path.join(appDirectory, 'web', 'client', 'product'));
-
-const frameworkPath = !isProject
-    ? path.join(appDirectory, 'web', 'client')
-    : fs.existsSync(path.resolve(appDirectory, './MapStore2'))
-        ? path.join(appDirectory, 'MapStore2', 'web', 'client')
-        : path.join(appDirectory, 'node_modules', 'mapstore', 'web', 'client');
+const frameworkPath = projectConfig.frameworkPath;
 
 const buildConfig = require(path.resolve(frameworkPath, '../../build/buildConfig'));
 const extractThemesPlugin = require(path.resolve(frameworkPath, '../../build/themes.js')).extractThemesPlugin;
 
-const webClientProductPath = path.resolve(frameworkPath, 'product');
-
-const jsPath = "js";
+const jsPath = projectConfig.jsPath;
 
 const paths = {
     base: path.resolve(appDirectory),
@@ -52,20 +44,8 @@ module.exports = () => {
         prod: false,
         publicPath,
         cssPrefix: `.${themePrefix}`,
-        bundles: {
-            [jsPath + '/mapstore']: path.join(webClientProductPath, 'app'),
-            ...(projectConfig.apps || []).reduce((acc, name) => ({
-                ...acc,
-                [jsPath + '/' + name.replace(/\.jsx|\.js/g, '')]: path.join(appDirectory, jsPath, 'apps', name)
-            }), {})
-        },
-        themeEntries: {
-            'themes/default': path.join(paths.framework, 'themes', 'default', 'theme.less'),
-            ...(projectConfig.themes || []).reduce((acc, name) => ({
-                ...acc,
-                ['themes/' + name]: path.join(appDirectory, 'themes', name, 'theme.less')
-            }), {})
-        },
+        bundles: projectConfig.apps,
+        themeEntries: projectConfig.themes,
         paths,
         alias: {
             '@mapstore/framework': paths.framework,
@@ -102,7 +82,7 @@ module.exports = () => {
             'node_modules'
         ],
         devServer: {
-            contentBase: isProject ? '.' : 'web/client',
+            contentBase: '.',
             ...projectConfig.devServer
         }
     });


### PR DESCRIPTION
This PR allows to override entries and paths with the packjson of the project.
This is the proposed configuration

```js
{
  ...,
  mapstore: {
    apps: [
      'path/to/dir-of-apps', // scan directory for js or jsx
      'path/to/dir/index.js', // point to a single file
      ['path/to/dir/fileName.js', 'file-name'] // point to a single file and replace the bundle name 
    ],
    html: [
      'path/to/dir-of-ejs', // scan directory for ejs
      'path/to/dir/index.ejs', // point to a single file
      ['path/to/dir/pageName.ejs', 'page-name.html'] // point to a single file and replace the html name
    ],
    themes: [
      'path/to/dir/themes', // scan directory for folder containing theme.less (name from folder)
      'path/to/dir/themes/default', // folder containing theme.less (name from folder)
      'path/to/dir/themes/default/theme.less' // theme.less file to use (name from folder)
    ]
  }
}
```

All the paths provided in the array of entries are merged in a single object so last entry in the array overrides the previous ones