### PR TITLE
Extend available configuration related to compile process

### DIFF
--- a/types/standard/README.md
+++ b/types/standard/README.md
@@ -70,6 +70,9 @@ The `mapstore` property inside the package.json allows to override and/or custom
 | `apps` | _{array}_ | mapstore application location. List of .js or .jsx entries: directories or files |
 | `html` | _{array}_ | mapstore html templates location. List of .ejs or .html entries: directories or files |
 | `themes` | _{array}_ | mapstore .less themes location: directories or files |
+| `output` | _{string}_ | output directory location |
+| `publicPath` | _{string}_ | public path used by the application |
+| `themePrefix` | _{string}_ | class name used to wrap all the classes inside the mapstore themes |
 | `templateParameters` | _{object}_ | overrides parameters of default html templates (index.ejs, embedded.ejs, api.ejs and unsupportedBrowser.ejs) |
 | templateParameters.`titleIndex` | _{string}_ |  |
 | templateParameters.`titleEmbedded` | _{string}_ |  |

--- a/types/standard/config/index.js
+++ b/types/standard/config/index.js
@@ -56,7 +56,6 @@ const devServerDefault = {
         }
     }
 };
-const devServer = fs.existsSync(devServerPath) ? require(devServerPath) : () => devServerDefault;
 
 function readEntriesPaths(entriesPaths, parse) {
     return entriesPaths.reduce((acc, entriesPath) => {
@@ -148,7 +147,11 @@ Build Entries:
 - Themes: ${renderEntries(themes)}
 `);
 
-module.exports = {
+const config = {
+    themePrefix: mapstoreConfig.themePrefix,
+    publicPath: mapstoreConfig.publicPath,
+    output: mapstoreConfig.output,
+    appDirectory,
     jsPath,
     frameworkPath,
     webClientProductPath,
@@ -157,8 +160,14 @@ module.exports = {
     // translations,
     themes,
     apps,
-    devServer: devServer(devServerDefault),
     htmlTemplates,
     html,
     templateParameters: mapstoreConfig.templateParameters || {}
+};
+
+const devServer = fs.existsSync(devServerPath) ? require(devServerPath) : () => devServerDefault;
+
+module.exports = {
+    ...config,
+    devServer: devServer(devServerDefault, config)
 };

--- a/types/standard/config/prod-webpack.config.js
+++ b/types/standard/config/prod-webpack.config.js
@@ -13,11 +13,11 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const appDirectory = fs.realpathSync(process.cwd());
 
-const publicPath = '';
-const output = 'dist/';
-
 const projectConfig = require('./index.js');
 const templateParameters = require('./templateParameters');
+
+const publicPath = projectConfig.publicPath || '';
+const output = projectConfig.output || 'dist/';
 
 const frameworkPath = projectConfig.frameworkPath;
 
@@ -36,7 +36,7 @@ const paths = {
     ]
 };
 
-const themePrefix = projectConfig.name;
+const themePrefix = projectConfig.themePrefix || projectConfig.name;
 
 module.exports = buildConfig({
     bundles: projectConfig.apps,

--- a/types/standard/config/webpack.config.js
+++ b/types/standard/config/webpack.config.js
@@ -12,11 +12,11 @@ const fs = require('fs');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const appDirectory = fs.realpathSync(process.cwd());
 
-const publicPath = '';
-const output = '';
-
 const projectConfig = require('./index.js');
 const templateParameters = require('./templateParameters');
+
+const publicPath = projectConfig.publicPath || '';
+const output = projectConfig.output || '';
 
 const frameworkPath = projectConfig.frameworkPath;
 
@@ -36,7 +36,7 @@ const paths = {
     ]
 };
 
-const themePrefix = projectConfig.name;
+const themePrefix = projectConfig.themePrefix || projectConfig.name;
 
 module.exports = () => {
 


### PR DESCRIPTION
This will help to remove the geonode type and use the standard instead

| property | type | description |
| --- | --- | --- |
| `output` | _{string}_ | output directory location |
| `publicPath` | _{string}_ | public path used by the application |
| `themePrefix` | _{string}_ | class name used to wrap all the classes inside the mapstore themes |