### PR TITLE
Issues with html-webpack-plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "fs-extra": "9.0.1",
     "glob": "7.1.1",
     "html-loader": "0.5.1",
-    "html-webpack-plugin": "4.5.0",
+    "html-webpack-plugin": "5.3.2",
     "jsdoc-jsx": "0.1.0",
     "karma": "5.2.3",
     "karma-chrome-launcher": "3.1.0",


### PR DESCRIPTION
We have anyway this error in project

```
-------------------------------------------------------------------------------
   start dev
 -------------------------------------------------------------------------------
 
 

Build Entries:
- Apps: {
    "js/cgd": "./js/apps/cgd.jsx"
}
- HTML: {
    "index.html": "./html/index.ejs"
}
- Themes: {
    "themes/default": "./themes/default/theme.less"
}

9% setup compilation LoaderOptionsPlugin[webpack-cli] TypeError: The 'compilation' argument must be an instance of Compilation
    at Function.getCompilationHooks (/home/offtherailz/work/projects/emsa/emsa-encws-geoserver/mapstore/cgd-fe/MapStore2/node_modules/webpack/lib/NormalModule.js:171:10)
    at /home/offtherailz/work/projects/emsa/emsa-encws-geoserver/mapstore/cgd-fe/MapStore2/node_modules/webpack/lib/LoaderOptionsPlugin.js:43:17
    at Hook.eval [as call] (eval at create (/home/offtherailz/work/projects/emsa/emsa-encws-geoserver/mapstore/cgd-fe/node_modules/webpack/node_modules/tapable/lib/HookCodeFactory.js:19:10), <anonymous>:198:1)
    at Hook.CALL_DELEGATE [as _call] (/home/offtherailz/work/projects/emsa/emsa-encws-geoserver/mapstore/cgd-fe/node_modules/webpack/node_modules/tapable/lib/Hook.js:14:14)
    at Compiler.newCompilation (/home/offtherailz/work/projects/emsa/emsa-encws-geoserver/mapstore/cgd-fe/node_modules/webpack/lib/Compiler.js:943:26)
    at /home/offtherailz/work/projects/emsa/emsa-encws-geoserver/mapstore/cgd-fe/node_modules/webpack/lib/Compiler.js:984:29
    at Hook.eval [as callAsync] (eval at create (/home/offtherailz/work/projects/emsa/emsa-encws-geoserver/mapstore/cgd-fe/node_modules/webpack/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:22:1)
    at Hook.CALL_ASYNC_DELEGATE [as _callAsync] (/home/offtherailz/work/projects/emsa/emsa-encws-geoserver/mapstore/cgd-fe/node_modules/webpack/node_modules/tapable/lib/Hook.js:18:14)
    at Compiler.compile (/home/offtherailz/work/projects/emsa/emsa-encws-geoserver/mapstore/cgd-fe/node_modules/webpack/lib/Compiler.js:979:28)
    at /home/offtherailz/work/projects/emsa/emsa-encws-geoserver/mapstore/cgd-fe/node_modules/webpack/lib/Watching.js:112:19
    at Hook.eval [as callAsync] (eval at create (/home/offtherailz/work/projects/emsa/emsa-encws-geoserver/mapstore/cgd-fe/node_modules/webpack/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:34:1)
    at Hook.CALL_ASYNC_DELEGATE [as _callAsync] (/home/offtherailz/work/projects/emsa/emsa-encws-geoserver/mapstore/cgd-fe/node_modules/webpack/node_modules/tapable/lib/Hook.js:18:14)
    at run (/home/offtherailz/work/projects/emsa/emsa-encws-geoserver/mapstore/cgd-fe/node_modules/webpack/lib/Watching.js:66:33)
    at Watching._go (/home/offtherailz/work/projects/emsa/emsa-encws-geoserver/mapstore/cgd-fe/node_modules/webpack/lib/Watching.js:123:4)
    at /home/offtherailz/work/projects/emsa/emsa-encws-geoserver/mapstore/cgd-fe/node_modules/webpack/lib/Watching.js:57:9
    at Compiler.readRecords (/home/offtherailz/work/projects/emsa/emsa-encws-geoserver/mapstore/cgd-fe/node_modules/webpack/lib/Compiler.js:821:11)
    at new Watching (/home/offtherailz/work/projects/emsa/emsa-encws-geoserver/mapstore/cgd-fe/node_modules/webpack/lib/Watching.js:54:17)
    at Compiler.watch (/home/offtherailz/work/projects/emsa/emsa-encws-geoserver/mapstore/cgd-fe/node_modules/webpack/lib/Compiler.js:362:19)
    at wdm (/home/offtherailz/work/projects/emsa/emsa-encws-geoserver/mapstore/cgd-fe/node_modules/webpack-dev-middleware/index.js:41:33)
    at Server.setupDevMiddleware (/home/offtherailz/work/projects/emsa/emsa-encws-geoserver/mapstore/cgd-fe/node_modules/webpack-dev-server/lib/Server.js:207:23)
    at new Server (/home/offtherailz/work/projects/emsa/emsa-encws-geoserver/mapstore/cgd-fe/node_modules/webpack-dev-server/lib/Server.js:118:10)
    at Command.<anonymous> (/home/offtherailz/work/projects/emsa/emsa-encws-geoserver/mapstore/cgd-fe/node_modules/@webpack-cli/serve/lib/index.js:239:34)
```