### PR TITLE
Ensures no trailing slash on jsPath

### DIFF
--- a/types/standard/config/prod-webpack.config.js
+++ b/types/standard/config/prod-webpack.config.js
@@ -25,10 +25,10 @@ const buildConfig = require(path.resolve(frameworkPath, '../../build/buildConfig
 const moduleFederationPlugin = require(path.resolve(frameworkPath, '../../build/moduleFederation.js')).plugin;
 const extractThemesPlugin = require(path.resolve(frameworkPath, '../../build/themes.js')).extractThemesPlugin;
 
-const ensureNoTrailingSlash = (path) => {
-    return path && path.endsWith("/") ? ensureNoTrailingSlash(path.slice(0, -1)) : path;
+const ensureTrailingSlash = (path) => {
+    return path && path.endsWith("/") ? path : path + "/";
 }
-const jsPath = ensureNoTrailingSlash(projectConfig.jsPath);
+const jsPath = ensureTrailingSlash(projectConfig.jsPath);
 const paths = {
     base: path.resolve(appDirectory),
     dist: path.resolve(appDirectory, output),

--- a/types/standard/config/prod-webpack.config.js
+++ b/types/standard/config/prod-webpack.config.js
@@ -25,12 +25,15 @@ const buildConfig = require(path.resolve(frameworkPath, '../../build/buildConfig
 const moduleFederationPlugin = require(path.resolve(frameworkPath, '../../build/moduleFederation.js')).plugin;
 const extractThemesPlugin = require(path.resolve(frameworkPath, '../../build/themes.js')).extractThemesPlugin;
 
-const jsPath = projectConfig.jsPath;
+const ensureTrailingSlash = (path) => {
+    return path?.endsWith("/") ? path : path + "/"
+}
+const jsPath = ensureTrailingSlash(projectConfig.jsPath);
 const paths = {
     base: path.resolve(appDirectory),
     dist: path.resolve(appDirectory, output),
     framework: frameworkPath,
-    chunks: jsPath + "/",
+    chunks: jsPath,
     code: [
         path.join(appDirectory, jsPath),
         frameworkPath

--- a/types/standard/config/prod-webpack.config.js
+++ b/types/standard/config/prod-webpack.config.js
@@ -25,10 +25,10 @@ const buildConfig = require(path.resolve(frameworkPath, '../../build/buildConfig
 const moduleFederationPlugin = require(path.resolve(frameworkPath, '../../build/moduleFederation.js')).plugin;
 const extractThemesPlugin = require(path.resolve(frameworkPath, '../../build/themes.js')).extractThemesPlugin;
 
-const ensureTrailingSlash = (path) => {
-    return path.endsWith("/") ? path : path + "/"
+const ensureNoTrailingSlash = (path) => {
+    return path && path.endsWith("/") ? ensureNoTrailingSlash(path.slice(0, -1)) : path;
 }
-const jsPath = ensureTrailingSlash(projectConfig.jsPath);
+const jsPath = ensureNoTrailingSlash(projectConfig.jsPath);
 const paths = {
     base: path.resolve(appDirectory),
     dist: path.resolve(appDirectory, output),

--- a/types/standard/config/prod-webpack.config.js
+++ b/types/standard/config/prod-webpack.config.js
@@ -26,7 +26,7 @@ const moduleFederationPlugin = require(path.resolve(frameworkPath, '../../build/
 const extractThemesPlugin = require(path.resolve(frameworkPath, '../../build/themes.js')).extractThemesPlugin;
 
 const ensureTrailingSlash = (path) => {
-    return path?.endsWith("/") ? path : path + "/"
+    return path.endsWith("/") ? path : path + "/"
 }
 const jsPath = ensureTrailingSlash(projectConfig.jsPath);
 const paths = {

--- a/types/standard/config/webpack.config.js
+++ b/types/standard/config/webpack.config.js
@@ -24,10 +24,10 @@ const buildConfig = require(path.resolve(frameworkPath, '../../build/buildConfig
 const moduleFederationPlugin = require(path.resolve(frameworkPath, '../../build/moduleFederation.js')).plugin;
 const extractThemesPlugin = require(path.resolve(frameworkPath, '../../build/themes.js')).extractThemesPlugin;
 
-const ensureNoTrailingSlash = (path) => {
-    return path && path.endsWith("/") ? ensureNoTrailingSlash(path.slice(0, -1)) : path;
+const ensureTrailingSlash = (path) => {
+    return path && path.endsWith("/") ? path : path + "/";
 }
-const jsPath = ensureNoTrailingSlash(projectConfig.jsPath);
+const jsPath = ensureTrailingSlash(projectConfig.jsPath);
 const paths = {
     base: path.resolve(appDirectory),
     dist: path.resolve(appDirectory, output),

--- a/types/standard/config/webpack.config.js
+++ b/types/standard/config/webpack.config.js
@@ -24,13 +24,16 @@ const buildConfig = require(path.resolve(frameworkPath, '../../build/buildConfig
 const moduleFederationPlugin = require(path.resolve(frameworkPath, '../../build/moduleFederation.js')).plugin;
 const extractThemesPlugin = require(path.resolve(frameworkPath, '../../build/themes.js')).extractThemesPlugin;
 
-const jsPath = projectConfig.jsPath;
+const ensureTrailingSlash = (path) => {
+    return path?.endsWith("/") ? path : path + "/"
+}
+const jsPath = ensureTrailingSlash(projectConfig.jsPath);
 
 const paths = {
     base: path.resolve(appDirectory),
     dist: path.resolve(appDirectory, output),
     framework: frameworkPath,
-    chunks: jsPath + "/",
+    chunks: jsPath,
     code: [
         path.join(appDirectory, jsPath),
         frameworkPath

--- a/types/standard/config/webpack.config.js
+++ b/types/standard/config/webpack.config.js
@@ -24,11 +24,10 @@ const buildConfig = require(path.resolve(frameworkPath, '../../build/buildConfig
 const moduleFederationPlugin = require(path.resolve(frameworkPath, '../../build/moduleFederation.js')).plugin;
 const extractThemesPlugin = require(path.resolve(frameworkPath, '../../build/themes.js')).extractThemesPlugin;
 
-const ensureTrailingSlash = (path) => {
-    return path.endsWith("/") ? path : path + "/"
+const ensureNoTrailingSlash = (path) => {
+    return path && path.endsWith("/") ? ensureNoTrailingSlash(path.slice(0, -1)) : path;
 }
-const jsPath = ensureTrailingSlash(projectConfig.jsPath);
-
+const jsPath = ensureNoTrailingSlash(projectConfig.jsPath);
 const paths = {
     base: path.resolve(appDirectory),
     dist: path.resolve(appDirectory, output),

--- a/types/standard/config/webpack.config.js
+++ b/types/standard/config/webpack.config.js
@@ -25,7 +25,7 @@ const moduleFederationPlugin = require(path.resolve(frameworkPath, '../../build/
 const extractThemesPlugin = require(path.resolve(frameworkPath, '../../build/themes.js')).extractThemesPlugin;
 
 const ensureTrailingSlash = (path) => {
-    return path?.endsWith("/") ? path : path + "/"
+    return path.endsWith("/") ? path : path + "/"
 }
 const jsPath = ensureTrailingSlash(projectConfig.jsPath);
 


### PR DESCRIPTION
Apps will get compiled a wrong js path which has two trailing slashes. Environments, which do not collapse these (as nginx does for example) will return an `HTTP 404`. This is true for example, when running GeoNode/Django via `python manage.py runserver`.

The index.js provides a `jsPath` which has already trailing slash. However, this change just ensures that the `jsPath` has a trailing slash and passes it right way through without adding further slashes.

**Update:** It seems that the trailing slash is completely unnecessary so I removed it