### PR TITLE
[Fixes #27] Add MAPSTORE_DEV flag to prod-webpack.config.js for hybrid dev/prod builds

### DIFF
--- a/types/standard/config/prod-webpack.config.js
+++ b/types/standard/config/prod-webpack.config.js
@@ -38,6 +38,7 @@ const paths = {
 };
 
 const themePrefix = projectConfig.themePrefix || projectConfig.name;
+const isDevMode = process.env.MAPSTORE_DEV === 'true';
 
 module.exports = buildConfig({
     bundles: projectConfig.apps,
@@ -79,7 +80,9 @@ module.exports = buildConfig({
             })
         )
     ],
-    prod: true,
+    prod: !isDevMode,
+    mode: isDevMode ? 'development' : 'production',
+    devtool: isDevMode ? 'source-map' : false,
     publicPath,
     cssPrefix: `.${themePrefix}`,
     alias: {
@@ -89,7 +92,7 @@ module.exports = buildConfig({
     projectConfig: {
         themePath: publicPath + 'themes',
         themePrefix: themePrefix,
-        version: projectConfig.version
+        version: isDevMode ? 'dev-staging' : projectConfig.version
     },
     resolveModules: [
         // resolve module installed inside the MapStore2 submodule

--- a/types/standard/config/prod-webpack.config.js
+++ b/types/standard/config/prod-webpack.config.js
@@ -38,7 +38,7 @@ const paths = {
 };
 
 const themePrefix = projectConfig.themePrefix || projectConfig.name;
-const isDevMode = process.env.MAPSTORE_DEV === 'true';
+const isCompileDevMode = process.env.MAPSTORE_COMPILE_DEV === 'true';
 
 module.exports = buildConfig({
     bundles: projectConfig.apps,
@@ -80,9 +80,9 @@ module.exports = buildConfig({
             })
         )
     ],
-    prod: !isDevMode,
-    mode: isDevMode ? 'development' : 'production',
-    devtool: isDevMode ? 'source-map' : false,
+    prod: !isCompileDevMode,
+    mode: isCompileDevMode ? 'development' : 'production',
+    devtool: isCompileDevMode ? 'source-map' : false,
     publicPath,
     cssPrefix: `.${themePrefix}`,
     alias: {
@@ -92,7 +92,7 @@ module.exports = buildConfig({
     projectConfig: {
         themePath: publicPath + 'themes',
         themePrefix: themePrefix,
-        version: isDevMode ? 'dev-staging' : projectConfig.version
+        version: isCompileDevMode ? 'dev-staging' : projectConfig.version
     },
     resolveModules: [
         // resolve module installed inside the MapStore2 submodule


### PR DESCRIPTION
Allows developers to build production-ready bundles with development features such as source maps by setting the MAPSTORE_COMPILE_DEV=true environment variable.

This is useful for deploying MapStore clients to environments like staging where full debug capability (e.g., unminified code and source maps) is required, while still including all assets (translations, configs, etc.).

Example usage from mapstore-client:
MAPSTORE_COMPILE_DEV=true mapstore-project compile && node postCompile

Changes:
- Added `isCompileDevMode` toggle based on MAPSTORE_COMPILE_DEV env var
- Conditionally set `mode`, `prod`, `devtool`, and `version` in the build config

This avoids the need for a separate dev-focused production build config and keeps the build logic centralised.

Closes geosolutions-it/mapstore-project#27